### PR TITLE
Decode PE command requests

### DIFF
--- a/src/protocolsupport/protocol/packet/middleimpl/readable/play/v_pe/CommandRequestPacket.java
+++ b/src/protocolsupport/protocol/packet/middleimpl/readable/play/v_pe/CommandRequestPacket.java
@@ -1,0 +1,55 @@
+package protocolsupport.protocol.packet.middleimpl.readable.play.v_pe;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import net.md_5.bungee.protocol.PacketWrapper;
+import net.md_5.bungee.protocol.packet.Chat;
+import protocolsupport.protocol.packet.middleimpl.readable.PEDefinedReadableMiddlePacket;
+import protocolsupport.protocol.serializer.MiscSerializer;
+import protocolsupport.protocol.serializer.StringSerializer;
+import protocolsupport.protocol.serializer.VarNumberSerializer;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class CommandRequestPacket extends PEDefinedReadableMiddlePacket {
+
+	public static final int PACKET_ID = 77;
+
+	protected String command;
+	//private static final int ORIGIN_PLAYER = 0;
+	//private static final int ORIGIN_BLOCK = 1;
+	//private static final int ORIGIN_MINECART_BLOCK = 2;
+	private static final int ORIGIN_DEV_CONSOLE = 3;
+	private static final int ORIGIN_TEST = 4;
+	//private static final int ORIGIN_AUTOMATION_PLAYER = 5;
+	//private static final int ORIGIN_CLIENT_AUTOMATION = 6;
+	//private static final int ORIGIN_DEDICATED_SERVER = 7;
+	//private static final int ORIGIN_ENTITY = 8;
+	//private static final int ORIGIN_VIRTUAL = 9;
+	//private static final int ORIGIN_GAME_ARGUMENT = 10;
+	//private static final int ORIGIN_ENTITY_SERVER = 11;
+
+	public CommandRequestPacket() {
+		super(PACKET_ID);
+	}
+
+	@Override
+	protected void read0(ByteBuf from) {
+		command = StringSerializer.readVarIntUTF8String(from);
+		// Command Origin Data
+		int type = VarNumberSerializer.readVarInt(from); // type
+		MiscSerializer.readUUIDLE(from); // UUID
+		StringSerializer.readVarIntUTF8String(from); // request ID
+		if (type == ORIGIN_DEV_CONSOLE || type == ORIGIN_TEST) {
+			VarNumberSerializer.readSVarLong(from); // ???
+		}
+		from.readBoolean(); // isInternal
+	}
+
+	@Override
+	public Collection<PacketWrapper> toNative() {
+		return Collections.singletonList(new PacketWrapper(new Chat(command), Unpooled.wrappedBuffer(readbytes)));
+	}
+
+}

--- a/src/protocolsupport/protocol/pipeline/version/v_pe/FromClientPacketDecoder.java
+++ b/src/protocolsupport/protocol/pipeline/version/v_pe/FromClientPacketDecoder.java
@@ -12,6 +12,7 @@ import protocolsupport.api.Connection;
 import protocolsupport.api.ProtocolVersion;
 import protocolsupport.protocol.packet.middle.ReadableMiddlePacket;
 import protocolsupport.protocol.packet.middleimpl.readable.handshake.v_pe.LoginHandshakePacket;
+import protocolsupport.protocol.packet.middleimpl.readable.play.v_pe.CommandRequestPacket;
 import protocolsupport.protocol.packet.middleimpl.readable.play.v_pe.FromClientChatPacket;
 import protocolsupport.protocol.serializer.VarNumberSerializer;
 import protocolsupport.protocol.storage.NetworkDataCache;
@@ -23,6 +24,7 @@ public class FromClientPacketDecoder extends MinecraftDecoder {
 	{
 		registry.register(Protocol.HANDSHAKE, LoginHandshakePacket.PACKET_ID, LoginHandshakePacket.class);
 		registry.register(Protocol.GAME, FromClientChatPacket.PACKET_ID, FromClientChatPacket.class);
+		registry.register(Protocol.GAME, CommandRequestPacket.PACKET_ID, CommandRequestPacket.class);
 	}
 
 	protected final Connection connection;

--- a/src/protocolsupport/protocol/serializer/MiscSerializer.java
+++ b/src/protocolsupport/protocol/serializer/MiscSerializer.java
@@ -1,11 +1,31 @@
 package protocolsupport.protocol.serializer;
 
 import java.text.MessageFormat;
+import java.util.UUID;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.DecoderException;
+import protocolsupport.api.ProtocolVersion;
 
 public class MiscSerializer {
+
+	public static UUID readUUID(ByteBuf from) {
+		return new UUID(from.readLong(), from.readLong());
+	}
+
+	public static UUID readUUIDLE(ByteBuf from) {
+		return new UUID(from.readLongLE(), from.readLongLE());
+	}
+
+	public static void writeUUID(ByteBuf to, UUID uuid) {
+		to.writeLong(uuid.getMostSignificantBits());
+		to.writeLong(uuid.getLeastSignificantBits());
+	}
+
+	public static void writeUUIDLE(ByteBuf to, UUID uuid) {
+		to.writeLongLE(uuid.getMostSignificantBits());
+		to.writeLongLE(uuid.getLeastSignificantBits());
+	}
 
 	public static void writeLFloat(ByteBuf to, float f) {
 		to.writeIntLE(Float.floatToIntBits(f));

--- a/src/protocolsupport/protocol/serializer/VarNumberSerializer.java
+++ b/src/protocolsupport/protocol/serializer/VarNumberSerializer.java
@@ -44,6 +44,12 @@ public class VarNumberSerializer {
 		to.writeByte((int) varlong);
 	}
 
+	public static long readSVarLong(ByteBuf from) {
+		long varlong = readVarLong(from);
+		return (varlong >> 1) ^ -(varlong & 1);
+	}
+
+
 	public static void writeSVarLong(ByteBuf to, long varlong) {
 		writeVarLong(to, (varlong << 1) ^ (varlong >> 63));
 	}


### PR DESCRIPTION
![https://cdn.discordapp.com/attachments/286106780189065216/387963383871307777/Screenshot_20171206-114739.png](https://cdn.discordapp.com/attachments/286106780189065216/387963383871307777/Screenshot_20171206-114739.png)

Not sure if this is the proper way to implement this, while PSBE looks like PS at the same time it doesn't (and I still couldn't figure out if this should be placed in the `readable` or in the `writeable` package... I thought I should kept it on the `readable` since I only read the packet from the client)